### PR TITLE
Add debounce to sticky messages. Untested.

### DIFF
--- a/events/sticky.js
+++ b/events/sticky.js
@@ -22,9 +22,9 @@ module.exports = async (msg) => {
 		clearTimeout(debounce);
 	}
 	debounce = setTimeout(() => {
+		debounce = null;
 		await msg.channel.send(dbRow.text)
 			.then(new_msg => sticky.setPost(msg.channel.id, new_msg.id))
 			.catch(e => console.log(e));
-		debounce = null;
 	}, TIMEOUT_S * 1000);
 };

--- a/events/sticky.js
+++ b/events/sticky.js
@@ -23,7 +23,7 @@ module.exports = async (msg) => {
 	}
 	debounce = setTimeout(() => {
 		debounce = null;
-		await msg.channel.send(dbRow.text)
+		msg.channel.send(dbRow.text)
 			.then(new_msg => sticky.setPost(msg.channel.id, new_msg.id))
 			.catch(e => console.log(e));
 	}, TIMEOUT_S * 1000);

--- a/events/sticky.js
+++ b/events/sticky.js
@@ -1,6 +1,10 @@
 const sticky = require('../models/sticky.js');
 const secure = require('../secure.json');
 
+const TIMEOUT_S = 30;
+
+let debounce = null;
+
 module.exports = async (msg) => {
 	if (msg.author.bot
 		|| msg.content[0] == msg.guild.commandPrefix
@@ -10,9 +14,17 @@ module.exports = async (msg) => {
 	let dbRow = await sticky.getPost(msg.channel.id);
 	if (!dbRow) return;
 
-	msg.channel.messages.fetch(dbRow.current_post)
-		.then(existing => existing.delete())
-		.catch(e => console.log(e))
-		.then(() => msg.channel.send(dbRow.text))
-		.then(new_msg => sticky.setPost(msg.channel.id, new_msg.id));
+	if (debounce === null) {
+		await msg.channel.messages.fetch(dbRow.current_post)
+			.then(existing => existing.delete())
+			.catch(e => console.log(e));
+	} else {
+		clearTimeout(debounce);
+	}
+	debounce = setTimeout(() => {
+		await msg.channel.send(dbRow.text)
+			.then(new_msg => sticky.setPost(msg.channel.id, new_msg.id))
+			.catch(e => console.log(e));
+		debounce = null;
+	}, TIMEOUT_S * 1000);
 };


### PR DESCRIPTION
Written in a vacuum, but should be pretty straight-forward:

This deletes the old sticky, if it's present. Then sets a timer to replace it which is reset on every new message.