### PR TITLE
Remove youtube shorts notifications

### DIFF
--- a/utils/youtube2.js
+++ b/utils/youtube2.js
@@ -4,7 +4,7 @@ const updates = require('../models/updates.js');
 
 const options = {
 	method: 'GET',
-	uri: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet,contentDetails&maxResults=25&playlistId=UUcXhhVwCT6_WqjkEniejRJQ&key=${secure.youtube}`,
+	uri: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet,contentDetails&maxResults=25&playlistId=UULFcXhhVwCT6_WqjkEniejRJQ&key=${secure.youtube}`,
 	json: true,
 };
 


### PR DESCRIPTION
This pull request proposes a fix for the shorts notifications on discord.
It appears the youtube api has some undocumented prefixes for playlists like all video's, or only shorts. [Source](https://stackoverflow.com/questions/71192605/how-do-i-get-youtube-shorts-from-youtube-api-data-v3)

I have not tested this code, but I did check that the [new playlist](https://www.youtube.com/playlist?list=UULFcXhhVwCT6_WqjkEniejRJQ) is valid and would only contain the main video's.